### PR TITLE
modify user entity test

### DIFF
--- a/backend/test/main_test.go
+++ b/backend/test/main_test.go
@@ -47,7 +47,6 @@ func loadFixture(t *testing.T, path string) {
 		testfixtures.Database(testDB),
 		testfixtures.Dialect("postgres"),
 		testfixtures.Directory(path),
-		testfixtures.ResetSequencesTo(1),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/backend/test/user_test.go
+++ b/backend/test/user_test.go
@@ -38,7 +38,7 @@ func TestCreateUser(t *testing.T) {
 			name: "case: Success",
 			args: args{
 				user: &ent.User{
-					ID: 50, Name: "user_x", Email: "user_x@example.com", Password: "password",
+					Name: "user_x", Email: "user_x@example.com", Password: "password",
 				},
 			},
 			wantErr: nil,
@@ -48,7 +48,7 @@ func TestCreateUser(t *testing.T) {
 			name: "case: Duplicate error",
 			args: args{
 				user: &ent.User{
-					ID: 60, Name: "user_y", Email: "user_y@example.com", Password: "password",
+					Name: "user_y", Email: "user_a@example.com", Password: "password",
 				},
 			},
 			wantErr: nil,


### PR DESCRIPTION
## overview
Userエンティティのテストコードを修正

## detail
* testfixtures.ResetSequencesTo(1)を設定していることでテストデータが登録されるたびにシーケンスの値がリセットされていたことでPRIMARY KEY 制約違反のエラーが発生していた。

* エラーメッセージ
```
ent: constraint failed: pq: duplicate key value violates unique constraint "users_pkey"
```

* シーケンスの値の確認
```
$ docker exec -it postgres.local psql -U admin -d sampledb -c "SELECT nextval('users_id_seq');"
 nextval
---------
       2
(1 row)
```

